### PR TITLE
Added project template

### DIFF
--- a/bundle.rb
+++ b/bundle.rb
@@ -116,7 +116,12 @@ END
         sub_menu.command 'Zebra Table'
  
     end
-    
+
+    menu.menu 'Templates' do |sub_menu|
+        sub_menu.command 'Basic page structure'
+        sub_menu.command 'Starter template'
+    end 
+  
     menu.separator
     
     menu.command 'Visit Project Homepage'

--- a/snippets/snippets.rb
+++ b/snippets/snippets.rb
@@ -771,3 +771,109 @@ snippet "Description" do |snip|
   '
 end
 
+snippet "Basic page structure" do |snip|
+  snip.trigger = "tbtbasic"
+  snip.expansion =
+  '
+    <!DOCTYPE html>
+    <html>
+    <head>
+    <title>Bootstrap 101 Template</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- Bootstrap -->
+    <link href="css/bootstrap.min.css" rel="stylesheet" media="screen">
+    </head>
+    <body>
+    <h1>Hello, world!</h1>
+    <script src="http://code.jquery.com/jquery.js"></script>
+    <script src="js/bootstrap.min.js"></script>
+    </body>
+    </html>
+  '
+end
+
+snippet "Starter template" do |snip|
+  snip.trigger = "tbtstarter"
+  snip.expansion =
+  '
+  <!DOCTYPE html>
+  <html lang="en">
+    <head>
+      <meta charset="utf-8">
+      <title>Bootstrap, from Twitter</title>
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <meta name="description" content="">
+      <meta name="author" content="">
+
+      <!-- Le styles -->
+      <link href="css/bootstrap.css" rel="stylesheet">
+      <style>
+        body {
+          padding-top: 60px; /* 60px to make the container go all the way to the bottom of the topbar */
+        }
+      </style>
+      <link href="css/bootstrap-responsive.css" rel="stylesheet">
+
+      <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->
+      <!--[if lt IE 9]>
+        <script src="js/html5shiv.js"></script>
+      <![endif]-->
+
+      <!-- Fav and touch icons -->
+      <link rel="apple-touch-icon-precomposed" sizes="144x144" href="ico/apple-touch-icon-144-precomposed.png">
+      <link rel="apple-touch-icon-precomposed" sizes="114x114" href="ico/apple-touch-icon-114-precomposed.png">
+      <link rel="apple-touch-icon-precomposed" sizes="72x72" href="ico/apple-touch-icon-72-precomposed.png">
+      <link rel="apple-touch-icon-precomposed" href="ico/apple-touch-icon-57-precomposed.png">
+      <link rel="shortcut icon" href="ico/favicon.png">
+    </head>
+
+    <body>
+
+      <div class="navbar navbar-inverse navbar-fixed-top">
+        <div class="navbar-inner">
+          <div class="container">
+            <button type="button" class="btn btn-navbar" data-toggle="collapse" data-target=".nav-collapse">
+              <span class="icon-bar"></span>
+              <span class="icon-bar"></span>
+              <span class="icon-bar"></span>
+            </button>
+            <a class="brand" href="#">Project name</a>
+            <div class="nav-collapse collapse">
+              <ul class="nav">
+                <li class="active"><a href="#">Home</a></li>
+                <li><a href="#about">About</a></li>
+                <li><a href="#contact">Contact</a></li>
+              </ul>
+            </div><!--/.nav-collapse -->
+          </div>
+        </div>
+      </div>
+
+      <div class="container">
+
+        <h1>Bootstrap starter template</h1>
+        <p>Use this document as a way to quick start any new project.<br> All you get is this message and a barebones HTML document.</p>
+
+      </div> <!-- /container -->
+
+      <!-- Le javascript
+      ================================================== -->
+      <!-- Placed at the end of the document so the pages load faster -->
+      <script src="js/jquery.js"></script>
+      <script src="js/bootstrap-transition.js"></script>
+      <script src="js/bootstrap-alert.js"></script>
+      <script src="js/bootstrap-modal.js"></script>
+      <script src="js/bootstrap-dropdown.js"></script>
+      <script src="js/bootstrap-scrollspy.js"></script>
+      <script src="js/bootstrap-tab.js"></script>
+      <script src="js/bootstrap-tooltip.js"></script>
+      <script src="js/bootstrap-popover.js"></script>
+      <script src="js/bootstrap-button.js"></script>
+      <script src="js/bootstrap-collapse.js"></script>
+      <script src="js/bootstrap-carousel.js"></script>
+      <script src="js/bootstrap-typeahead.js"></script>
+
+    </body>
+  </html>
+  '
+end

--- a/templates/project_templates.rb
+++ b/templates/project_templates.rb
@@ -1,0 +1,11 @@
+require 'ruble'
+ 
+project_template "Twitter Bootstrap" do |t|
+  t.type = :web
+  t.tags = ['Web']
+  t.id = "com.aptana.project.template.web.twitterbootstrap"
+  t.location = "git://github.com/bowerjs/bootstrap.git"
+  t.description = "Template based on Twitter Bootstrap. Requires network access."
+  t.icon = "https://raw.github.com/twitter/bootstrap/gh-pages/assets/img/bootstrap-docs-readme.png"
+  t.tags = ['Web']
+end


### PR DESCRIPTION
The compiled version of Twitter Bootstrap can be added to a new project simply by going to New Project... -> Web Project -> Twitter Bootstrap

Two things:
a. Not familiar with how IDs in Aptana Ruble programming work. I used com.aptana.project.template.web.twitterbootstrap, but this is probably wrong (I.e., it uses the 1st party "com.aptana.*" namespace.). You may wish to amend this.

b. The icon being pulled looks a little bit off, probably because it's originally 200x200 and not 48x48 as requested. You may wish to update the path with a properly-sized one added locally.

For more info on project templates, see: https://wiki.appcelerator.org/display/tis/Creating+a+new+template#Creatinganewtemplate-Creatinganewprojecttemplate
